### PR TITLE
Drupal 10 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,6 @@
   },
   "require": {
     "php": ">=7.2",
-    "drupal/drupal-extension": "~4.0"
+    "drupal/drupal-extension": "v5.0.0alpha1"
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     }
   },
   "require": {
-    "php": ">=7.2",
+    "php": ">=7.2 || >=8.0",
     "drupal/drupal-extension": "v5.0.0alpha1"
   }
 }


### PR DESCRIPTION
I have recently started a new Drupal 10 project and we have seen that for the extension to work we need drupal-extensions version 5, still in beta, so I propose to update the major version of behat-drupal-translations with this new compatibility.